### PR TITLE
Replace get_absolute_root_url through get_root_url

### DIFF
--- a/map.php
+++ b/map.php
@@ -59,7 +59,7 @@ if ( !isset($_GET['ll']) /*and ($page['section']!='categories' or isset($page['c
 }
 
 
-$map_data_url  = get_absolute_root_url().'plugins/'.$rvm_dir.'/map_data.php?';
+$map_data_url  = get_root_url().'plugins/'.$rvm_dir.'/map_data.php?';
 $map_data_url .= $section;
 
 $template->set_filename( 'map', dirname(__FILE__).'/template/map.tpl' );
@@ -69,7 +69,7 @@ $template->assign(
 		'GMAPS_API_KEY' => !empty($conf['gmaps_api_key']) ? $conf['gmaps_api_key'] : '',
     'CONTENT_ENCODING' => get_pwg_charset(),
     'RVM_PLUGIN_VERSION' => RVM_PLUGIN_VERSION,
-    'PLUGIN_ROOT_URL' => get_absolute_root_url().'plugins/'.$rvm_dir,
+    'PLUGIN_ROOT_URL' => get_root_url().'plugins/'.$rvm_dir,
 		'PLUGIN_LOCATION' => 'plugins/'.$rvm_dir,
     'U_MAP_DATA' => $map_data_url,
     'GALLERY_TITLE' => $conf['gallery_title'],


### PR DESCRIPTION
If you're behind you reverse proxy like varnish for instance and you webserver is running on a non-reachable port the global map doesn't work at all. get_absolute_root_url will return something like "http://domain:8080/...". With get_root_url this will be fixed.